### PR TITLE
Touchpad Fixes

### DIFF
--- a/moused/src/moused.c
+++ b/moused/src/moused.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/input.h>
+#include <linux/input-event-codes.h>
 #include <linux/uinput.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -63,10 +64,15 @@ int new_device() {
     // Clone the enabled event types and codes of the device
     clone_enabled_event_types_and_codes(input, fd);
 
+    // Set device properties to match physical trackpad (PROP=5)
+    // This tells libinput it's a buttonpad-style touchpad, enabling proper gesture support
+    ioctl(fd, UI_SET_PROPBIT, INPUT_PROP_POINTER);     // 0x00
+    ioctl(fd, UI_SET_PROPBIT, INPUT_PROP_BUTTONPAD);   // 0x02
+
     // Setup the device
     struct uinput_setup uisetup = {0};
     memset(&uisetup, 0, sizeof(uisetup));
-    strcpy(uisetup.name, "MiniBookSupport Virtual Mouse");
+    strcpy(uisetup.name, "MiniBookSupport Virtual Touchpad");
     uisetup.id.bustype = BUS_USB;
     uisetup.id.vendor = 0x1234;
     uisetup.id.product = 0x5678;

--- a/moused/src/moused.c
+++ b/moused/src/moused.c
@@ -48,6 +48,28 @@ double smoothed_y = -1.0;
 #define SMOOTHING_MODERATE 0.6  // Moderate smoothing factor (40% old, 60% new)
 #define SMOOTHING_LIGHT 0.85    // Light smoothing factor (15% old, 85% new)
 
+// Multi-touch tracking for scrolling
+#define MAX_SLOTS 10
+typedef struct {
+    int tracking_id;  // -1 means slot is empty
+    int x;
+    int y;
+} touch_slot_t;
+
+touch_slot_t touch_slots[MAX_SLOTS] = {{-1, 0, 0}};
+int current_slot = 0;
+int active_fingers = 0;
+int prev_active_fingers = 0;  // Track previous state to detect transitions
+int stable_finger_count = 0;  // Debounced finger count
+int last_scroll_y = -1;
+double scroll_velocity = 0.0;
+
+// Scroll parameters
+#define SCROLL_THRESHOLD 3       // Minimum movement to trigger scroll (pixels)
+#define SCROLL_SCALE 3.0         // Scale factor for scroll sensitivity (higher = faster)
+#define INERTIA_DECAY 0.92       // Velocity decay factor per frame (higher = longer inertia)
+#define INERTIA_MIN_VELOCITY 0.5 // Stop when velocity drops below this
+
 // Recovery the device
 void recovery_device() {
     // Enable the pointer
@@ -80,6 +102,11 @@ int new_device() {
 
     // Clone the enabled event types and codes of the device
     clone_enabled_event_types_and_codes(input, fd);
+
+    // Enable scroll wheel events for two-finger scrolling
+    ioctl(fd, UI_SET_EVBIT, EV_REL);
+    ioctl(fd, UI_SET_RELBIT, REL_WHEEL);
+    ioctl(fd, UI_SET_RELBIT, REL_HWHEEL);
 
     // Set device properties to match physical trackpad (PROP=5)
     // This tells libinput it's a buttonpad-style touchpad, enabling proper gesture support
@@ -286,6 +313,18 @@ int main(int argc, char *argv[]) {
         switch (event.type) {
         case EV_SYN:
             debug_printf("EV_SYN: %d %d\n", event.code, event.value);
+
+            // Stabilize finger count at frame boundaries
+            if (event.code == SYN_REPORT) {
+                // If finger count changed, reset scroll position to avoid jumps
+                if (active_fingers != prev_active_fingers) {
+                    last_scroll_y = -1;
+                    debug_printf("Finger count changed: %d -> %d\n", prev_active_fingers, active_fingers);
+                    prev_active_fingers = active_fingers;
+                }
+                stable_finger_count = active_fingers;
+            }
+
             if (is_enabled_passthrough) {
                 emit(output, event.type, event.code, event.value);
             }
@@ -358,9 +397,99 @@ int main(int argc, char *argv[]) {
         case EV_ABS:
             debug_printf("EV_ABS: %d %d\n", event.code, event.value);
             if (is_enabled_passthrough) {
-                // Apply adaptive exponential smoothing for cursor position
-                if (event.code == ABS_X || event.code == ABS_Y ||
-                    event.code == ABS_MT_POSITION_X || event.code == ABS_MT_POSITION_Y) {
+                // Track multi-touch for two-finger scrolling
+                if (event.code == ABS_MT_SLOT) {
+                    current_slot = event.value;
+                    if (current_slot >= MAX_SLOTS) current_slot = MAX_SLOTS - 1;
+                    debug_printf("MT_SLOT: %d\n", current_slot);
+                } else if (event.code == ABS_MT_TRACKING_ID) {
+                    if (event.value == -1) {
+                        // Finger lifted
+                        if (touch_slots[current_slot].tracking_id != -1) {
+                            active_fingers--;
+                            debug_printf("Finger lifted. Active fingers: %d\n", active_fingers);
+                        }
+                        touch_slots[current_slot].tracking_id = -1;
+                        if (active_fingers == 0) {
+                            last_scroll_y = -1;  // Reset scroll tracking
+                        }
+                    } else {
+                        // New finger down
+                        if (touch_slots[current_slot].tracking_id == -1) {
+                            active_fingers++;
+                            debug_printf("Finger down. Active fingers: %d\n", active_fingers);
+                        }
+                        touch_slots[current_slot].tracking_id = event.value;
+                    }
+                } else if (event.code == ABS_MT_POSITION_X) {
+                    touch_slots[current_slot].x = event.value;
+                } else if (event.code == ABS_MT_POSITION_Y) {
+                    touch_slots[current_slot].y = event.value;
+
+                    // If we have 2 fingers (use stable count to avoid mid-frame transitions), calculate scroll
+                    if (stable_finger_count == 2) {
+                        // Calculate average Y position of all active fingers
+                        int sum_y = 0, count = 0;
+                        for (int i = 0; i < MAX_SLOTS; i++) {
+                            if (touch_slots[i].tracking_id != -1) {
+                                sum_y += touch_slots[i].y;
+                                count++;
+                            }
+                        }
+                        int avg_y = sum_y / count;
+
+                        if (last_scroll_y != -1) {
+                            int delta_y = avg_y - last_scroll_y;
+                            int abs_delta = delta_y < 0 ? -delta_y : delta_y;
+                            if (abs_delta > SCROLL_THRESHOLD) {
+                                // Generate scroll event (negative for natural scrolling)
+                                // Scale and round to get smooth scrolling
+                                double scroll_amount_float = -delta_y * SCROLL_SCALE / 10.0;
+                                int scroll_amount = scroll_amount_float >= 0
+                                    ? (int)(scroll_amount_float + 0.5)
+                                    : (int)(scroll_amount_float - 0.5);
+
+                                if (scroll_amount != 0) {
+                                    emit(output, EV_REL, REL_WHEEL, scroll_amount);
+                                    emit(output, EV_SYN, SYN_REPORT, 0);
+                                    debug_printf("Scroll: %d (delta_y=%d)\n", scroll_amount, delta_y);
+
+                                    // Track velocity for inertia
+                                    scroll_velocity = scroll_amount_float;
+                                }
+                            }
+                        }
+                        last_scroll_y = avg_y;
+
+                        // DON'T emit position events when scrolling - this prevents pinch zoom gestures
+                        break;
+                    }
+                }
+
+                // When scrolling (2+ fingers), suppress ALL multi-touch events to prevent gesture confusion
+                if (stable_finger_count >= 2) {
+                    // Only allow non-MT events through
+                    if (event.code != ABS_MT_SLOT &&
+                        event.code != ABS_MT_TRACKING_ID &&
+                        event.code != ABS_MT_POSITION_X &&
+                        event.code != ABS_MT_POSITION_Y &&
+                        event.code != ABS_MT_TOUCH_MAJOR &&
+                        event.code != ABS_MT_TOUCH_MINOR &&
+                        event.code != ABS_MT_PRESSURE) {
+                        emit(output, event.type, event.code, event.value);
+                    }
+                    break;
+                }
+
+                // Emit MT tracking events for single finger
+                if (event.code == ABS_MT_SLOT || event.code == ABS_MT_TRACKING_ID) {
+                    emit(output, event.type, event.code, event.value);
+                }
+
+                // Apply adaptive exponential smoothing for cursor position (single finger only)
+                if ((event.code == ABS_X || event.code == ABS_Y ||
+                    event.code == ABS_MT_POSITION_X || event.code == ABS_MT_POSITION_Y) &&
+                    stable_finger_count == 1) {
                     // Use appropriate smoothing variables based on event code
                     int is_x = (event.code == ABS_X || event.code == ABS_MT_POSITION_X);
                     double *smoothed = is_x ? &smoothed_x : &smoothed_y;

--- a/moused/src/moused.c
+++ b/moused/src/moused.c
@@ -31,6 +31,14 @@ int input = -1, output = -1;
 int is_enabled_passthrough = 1;
 int is_enabled_calibration = 0;
 
+// Position filtering to reduce jitter and lift noise
+int last_abs_x = -1;
+int last_abs_y = -1;
+int prev_delta_x = 0;
+int prev_delta_y = 0;
+#define JITTER_THRESHOLD 3      // Ignore movements smaller than this (pixels)
+#define JUMP_THRESHOLD 50       // Suppress jumps larger than this (likely lift noise)
+
 // Recovery the device
 void recovery_device() {
     // Enable the pointer
@@ -287,6 +295,14 @@ int main(int argc, char *argv[]) {
                     press_key(event.code);
                 } else if (event.value == 0) {
                     release_key(event.code);
+                    // Reset position tracking when finger lifts
+                    if (event.code == BTN_TOUCH) {
+                        last_abs_x = -1;
+                        last_abs_y = -1;
+                        prev_delta_x = 0;
+                        prev_delta_y = 0;
+                        debug_printf("Reset position tracking (finger lifted)\n");
+                    }
                 }
                 emit(output, event.type, event.code, event.value);
             }
@@ -331,6 +347,34 @@ int main(int argc, char *argv[]) {
         case EV_ABS:
             debug_printf("EV_ABS: %d %d\n", event.code, event.value);
             if (is_enabled_passthrough) {
+                // Apply filtering for cursor position (ABS_X and ABS_Y)
+                if (event.code == ABS_X || event.code == ABS_Y) {
+                    int *last_pos = (event.code == ABS_X) ? &last_abs_x : &last_abs_y;
+                    int *prev_delta = (event.code == ABS_X) ? &prev_delta_x : &prev_delta_y;
+
+                    if (*last_pos != -1) {
+                        int delta = event.value - *last_pos;
+                        int abs_delta = (delta < 0) ? -delta : delta;
+
+                        // Suppress jitter: ignore very small movements
+                        if (abs_delta < JITTER_THRESHOLD) {
+                            debug_printf("Filtering jitter: delta=%d\n", delta);
+                            break;  // Don't emit, don't update position
+                        }
+
+                        // Suppress lift noise: detect sudden large jumps
+                        int prev_abs_delta = (*prev_delta < 0) ? -*prev_delta : *prev_delta;
+                        if (abs_delta > JUMP_THRESHOLD && prev_abs_delta < JUMP_THRESHOLD) {
+                            debug_printf("Filtering jump: delta=%d (prev=%d)\n", delta, *prev_delta);
+                            break;  // Don't emit, don't update position
+                        }
+
+                        *prev_delta = delta;
+                    }
+
+                    *last_pos = event.value;
+                }
+
                 emit(output, event.type, event.code, event.value);
             }
             break;

--- a/moused/src/moused.c
+++ b/moused/src/moused.c
@@ -36,8 +36,17 @@ int last_abs_x = -1;
 int last_abs_y = -1;
 int prev_delta_x = 0;
 int prev_delta_y = 0;
-#define JITTER_THRESHOLD 3      // Ignore movements smaller than this (pixels)
-#define JUMP_THRESHOLD 50       // Suppress jumps larger than this (likely lift noise)
+double smoothed_x = -1.0;
+double smoothed_y = -1.0;
+
+// Adaptive smoothing thresholds
+#define DEADZONE 2              // Ignore movements smaller than this (sub-pixel jitter)
+#define SMALL_MOVEMENT 10       // Movements below this get heavy smoothing
+#define MEDIUM_MOVEMENT 25      // Movements below this get moderate smoothing
+#define LIFT_NOISE_THRESHOLD 15 // Suppress sudden jumps larger than this (likely lift noise)
+#define SMOOTHING_HEAVY 0.3     // Heavy smoothing factor (70% old, 30% new)
+#define SMOOTHING_MODERATE 0.6  // Moderate smoothing factor (40% old, 60% new)
+#define SMOOTHING_LIGHT 0.85    // Light smoothing factor (15% old, 85% new)
 
 // Recovery the device
 void recovery_device() {
@@ -301,6 +310,8 @@ int main(int argc, char *argv[]) {
                         last_abs_y = -1;
                         prev_delta_x = 0;
                         prev_delta_y = 0;
+                        smoothed_x = -1.0;
+                        smoothed_y = -1.0;
                         debug_printf("Reset position tracking (finger lifted)\n");
                     }
                 }
@@ -347,35 +358,67 @@ int main(int argc, char *argv[]) {
         case EV_ABS:
             debug_printf("EV_ABS: %d %d\n", event.code, event.value);
             if (is_enabled_passthrough) {
-                // Apply filtering for cursor position (ABS_X and ABS_Y)
-                if (event.code == ABS_X || event.code == ABS_Y) {
-                    int *last_pos = (event.code == ABS_X) ? &last_abs_x : &last_abs_y;
-                    int *prev_delta = (event.code == ABS_X) ? &prev_delta_x : &prev_delta_y;
+                // Apply adaptive exponential smoothing for cursor position
+                if (event.code == ABS_X || event.code == ABS_Y ||
+                    event.code == ABS_MT_POSITION_X || event.code == ABS_MT_POSITION_Y) {
+                    // Use appropriate smoothing variables based on event code
+                    int is_x = (event.code == ABS_X || event.code == ABS_MT_POSITION_X);
+                    double *smoothed = is_x ? &smoothed_x : &smoothed_y;
+                    int *last_pos = is_x ? &last_abs_x : &last_abs_y;
 
-                    if (*last_pos != -1) {
-                        int delta = event.value - *last_pos;
-                        int abs_delta = (delta < 0) ? -delta : delta;
-
-                        // Suppress jitter: ignore very small movements
-                        if (abs_delta < JITTER_THRESHOLD) {
-                            debug_printf("Filtering jitter: delta=%d\n", delta);
-                            break;  // Don't emit, don't update position
-                        }
-
-                        // Suppress lift noise: detect sudden large jumps
-                        int prev_abs_delta = (*prev_delta < 0) ? -*prev_delta : *prev_delta;
-                        if (abs_delta > JUMP_THRESHOLD && prev_abs_delta < JUMP_THRESHOLD) {
-                            debug_printf("Filtering jump: delta=%d (prev=%d)\n", delta, *prev_delta);
-                            break;  // Don't emit, don't update position
-                        }
-
-                        *prev_delta = delta;
+                    // Initialize smoothed position on first touch
+                    if (*smoothed < 0.0) {
+                        *smoothed = (double)event.value;
+                        *last_pos = event.value;
+                        emit(output, event.type, event.code, event.value);
+                        break;
                     }
 
-                    *last_pos = event.value;
-                }
+                    // Calculate delta from raw position
+                    int delta = event.value - *last_pos;
+                    int abs_delta = (delta < 0) ? -delta : delta;
 
-                emit(output, event.type, event.code, event.value);
+                    // Get previous delta for jump detection
+                    int *prev_delta = is_x ? &prev_delta_x : &prev_delta_y;
+                    int prev_abs_delta = (*prev_delta < 0) ? -*prev_delta : *prev_delta;
+
+                    // Deadzone: ignore sub-pixel jitter when nearly still
+                    if (abs_delta < DEADZONE) {
+                        debug_printf("Deadzone: ignoring delta=%d\n", delta);
+                        break;  // Don't emit, don't update
+                    }
+
+                    // Lift noise detection: suppress sudden large jumps after small movements
+                    if (abs_delta > LIFT_NOISE_THRESHOLD && prev_abs_delta < SMALL_MOVEMENT) {
+                        debug_printf("Lift noise: suppressing jump delta=%d (prev=%d)\n", delta, *prev_delta);
+                        break;  // Don't emit, don't update
+                    }
+
+                    // Adaptive smoothing based on movement size
+                    double alpha;
+                    if (abs_delta < SMALL_MOVEMENT) {
+                        alpha = SMOOTHING_HEAVY;      // Heavy smoothing for small jittery movements
+                        debug_printf("Heavy smoothing: delta=%d\n", delta);
+                    } else if (abs_delta < MEDIUM_MOVEMENT) {
+                        alpha = SMOOTHING_MODERATE;   // Moderate smoothing for medium movements
+                        debug_printf("Moderate smoothing: delta=%d\n", delta);
+                    } else {
+                        alpha = SMOOTHING_LIGHT;      // Light smoothing for large intentional movements
+                        debug_printf("Light smoothing: delta=%d\n", delta);
+                    }
+
+                    // Apply exponential moving average: smoothed = alpha * new + (1-alpha) * old
+                    *smoothed = alpha * (double)event.value + (1.0 - alpha) * (*smoothed);
+
+                    // Emit the smoothed position
+                    int smoothed_value = (int)(*smoothed + 0.5);  // Round to nearest integer
+                    *last_pos = event.value;  // Track raw position for delta calculation
+                    *prev_delta = delta;      // Track for jump detection
+
+                    emit(output, event.type, event.code, smoothed_value);
+                } else {
+                    emit(output, event.type, event.code, event.value);
+                }
             }
             break;
         default:

--- a/test-fix.sh
+++ b/test-fix.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Testing physical click and drag fix..."
+echo "======================================"
+echo ""
+echo "Stopping moused service..."
+sudo systemctl stop moused
+
+echo ""
+echo "Starting moused with fix..."
+echo "Try to do a PHYSICAL CLICK AND DRAG now!"
+echo "The cursor should move while holding the physical button."
+echo ""
+echo "Press Ctrl+C when done testing to restore the service."
+echo ""
+
+# Run the fixed moused
+sudo ./moused/bin/moused
+
+# When user presses Ctrl+C, this will run
+echo ""
+echo "Restarting moused service..."
+sudo systemctl start moused
+echo "Done!"

--- a/test-jitter-config.sh
+++ b/test-jitter-config.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+
+# Interactive Jitter Configuration Test Script for moused
+# Allows users to test different jitter and jump threshold values
+# and optionally install the modified version
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+JITTER_THRESHOLD=3
+JUMP_THRESHOLD=50
+NEED_TO_RESTART_SERVICE=false
+
+# Paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOUSED_DIR="$SCRIPT_DIR/moused"
+MOUSED_SRC="$MOUSED_DIR/src/moused.c"
+MOUSED_BACKUP="$MOUSED_SRC.backup"
+MOUSED_BIN="$MOUSED_DIR/bin/moused"
+
+# Function to display usage
+usage() {
+    cat << EOF
+${BLUE}Interactive Jitter Configuration Test Script${NC}
+
+Usage: $0 [OPTIONS]
+
+Options:
+    --jitter-threshold N    Set jitter threshold (default: 3 pixels)
+    --jump-threshold N      Set jump threshold (default: 50 pixels)
+    --jitter N              Short form for --jitter-threshold
+    --jump N                Short form for --jump-threshold
+    -h, --help              Show this help message
+
+Description:
+    This script allows you to test different jitter suppression settings
+    for the moused trackpad driver. It will:
+
+    1. Temporarily modify the threshold values in moused.c
+    2. Build a test version of moused
+    3. Stop the system service and run the test version
+    4. Let you test the trackpad behavior
+    5. Optionally install the version with your preferred settings
+
+Examples:
+    # Test with default values (jitter=3, jump=50)
+    $0
+
+    # Test with custom values
+    $0 --jitter-threshold 5 --jump-threshold 100
+
+    # Using short form
+    $0 --jitter 2 --jump 30
+
+Current defaults:
+    Jitter threshold: ${GREEN}3 pixels${NC} (movements smaller than this are ignored)
+    Jump threshold:   ${GREEN}50 pixels${NC} (sudden jumps larger than this are suppressed)
+
+EOF
+    exit 0
+}
+
+# Function to print colored messages
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to clean up on exit
+cleanup() {
+    if [ -f "$MOUSED_BACKUP" ]; then
+        print_info "Restoring original moused.c..."
+        mv "$MOUSED_BACKUP" "$MOUSED_SRC"
+        print_success "Original file restored"
+    fi
+
+    # Clean up build artifacts
+    if [ -d "$MOUSED_DIR" ]; then
+        cd "$MOUSED_DIR"
+        make clean > /dev/null 2>&1 || true
+    fi
+}
+
+# Function to restore system service
+restore_service() {
+    if [ "$NEED_TO_RESTART_SERVICE" = "true" ]; then
+        if systemctl is-active --quiet moused.service 2>/dev/null; then
+            print_info "System service is already running"
+        else
+            print_info "Restarting system moused service..."
+            sudo systemctl start moused.service 2>/dev/null || print_warning "Could not restart system service (it may not be installed)"
+        fi
+    fi
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --jitter-threshold|--jitter)
+            JITTER_THRESHOLD="$2"
+            shift 2
+            ;;
+        --jump-threshold|--jump)
+            JUMP_THRESHOLD="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate numeric inputs
+if ! [[ "$JITTER_THRESHOLD" =~ ^[0-9]+$ ]]; then
+    print_error "Jitter threshold must be a positive integer"
+    exit 1
+fi
+
+if ! [[ "$JUMP_THRESHOLD" =~ ^[0-9]+$ ]]; then
+    print_error "Jump threshold must be a positive integer"
+    exit 1
+fi
+
+# Validate paths
+if [ ! -f "$MOUSED_SRC" ]; then
+    print_error "Could not find moused.c at: $MOUSED_SRC"
+    exit 1
+fi
+
+# Set up cleanup trap (will be modified during testing)
+trap 'cleanup; restore_service' EXIT
+
+# Display configuration
+echo -e "\n${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}  Jitter Configuration Test${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "Jitter threshold: ${GREEN}${JITTER_THRESHOLD}${NC} pixels"
+echo -e "Jump threshold:   ${GREEN}${JUMP_THRESHOLD}${NC} pixels"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+
+print_info "These settings will be tested (not installed yet)"
+echo ""
+
+# Backup original file
+print_info "Backing up original moused.c..."
+cp "$MOUSED_SRC" "$MOUSED_BACKUP"
+print_success "Backup created"
+
+# Modify the #define values
+print_info "Modifying threshold values in moused.c..."
+sed -i "s/^#define JITTER_THRESHOLD.*/#define JITTER_THRESHOLD ${JITTER_THRESHOLD}      \/\/ Ignore movements smaller than this (pixels)/" "$MOUSED_SRC"
+sed -i "s/^#define JUMP_THRESHOLD.*/#define JUMP_THRESHOLD ${JUMP_THRESHOLD}       \/\/ Suppress jumps larger than this (likely lift noise)/" "$MOUSED_SRC"
+print_success "Thresholds updated"
+
+# Build the test version
+print_info "Building test version of moused..."
+cd "$MOUSED_DIR"
+if make clean > /dev/null 2>&1 && make > /dev/null 2>&1; then
+    print_success "Build completed successfully"
+else
+    print_error "Build failed"
+    exit 1
+fi
+
+# Check if moused service is running and stop it
+NEED_TO_RESTART_SERVICE=false
+if systemctl is-active --quiet moused.service 2>/dev/null; then
+    NEED_TO_RESTART_SERVICE=true
+    print_warning "System moused service is running. It needs to be stopped for testing."
+    print_info "Stopping system moused service..."
+    sudo systemctl stop moused.service
+    print_success "Service stopped"
+fi
+
+# Run the test version
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}  Starting test version of moused${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "Settings:"
+echo -e "  • Jitter threshold: ${GREEN}${JITTER_THRESHOLD}${NC} pixels"
+echo -e "  • Jump threshold:   ${GREEN}${JUMP_THRESHOLD}${NC} pixels"
+echo ""
+echo -e "${YELLOW}Test your trackpad now!${NC}"
+echo -e "Try moving the cursor slowly and quickly to feel the difference."
+echo ""
+echo -e "Press ${GREEN}Enter${NC} when you're done testing to proceed to the menu"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+# Run moused in the background
+sudo "$MOUSED_BIN" -d &
+MOUSED_PID=$!
+
+# Wait for user to press Enter
+read -r
+
+# Stop the test moused instance
+print_info "Stopping test instance..."
+sudo kill $MOUSED_PID 2>/dev/null || true
+sleep 1
+print_success "Test instance stopped"
+
+# After testing, ask user what to do
+echo ""
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}  Test Complete${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo "What would you like to do?"
+echo ""
+echo "  1) Install these settings permanently"
+echo "  2) Discard and restore original settings"
+echo "  3) Try different values"
+echo ""
+read -p "Enter your choice (1/2/3): " -n 1 -r
+echo ""
+echo ""
+
+case $REPLY in
+    1)
+        print_info "Installing moused with new settings..."
+        cd "$MOUSED_DIR"
+        if sudo make install; then
+            print_success "Installation complete!"
+            echo ""
+            echo -e "${GREEN}Settings installed:${NC}"
+            echo -e "  • Jitter threshold: ${GREEN}${JITTER_THRESHOLD}${NC} pixels"
+            echo -e "  • Jump threshold:   ${GREEN}${JUMP_THRESHOLD}${NC} pixels"
+            echo ""
+
+            # Remove backup since we're keeping the changes
+            rm -f "$MOUSED_BACKUP"
+
+            # Restart service if it was running before
+            if [ "$NEED_TO_RESTART_SERVICE" = "true" ]; then
+                print_info "Restarting moused service..."
+                sudo systemctl restart moused.service
+                print_success "Service restarted with new settings"
+            fi
+
+            # Don't restore service on exit since we already restarted it
+            NEED_TO_RESTART_SERVICE=false
+        else
+            print_error "Installation failed"
+            restore_service
+            exit 1
+        fi
+        ;;
+    2)
+        print_info "Discarding changes and restoring original settings..."
+        mv "$MOUSED_BACKUP" "$MOUSED_SRC"
+        print_success "Original settings restored"
+        restore_service
+        ;;
+    3)
+        print_info "Restoring original settings..."
+        mv "$MOUSED_BACKUP" "$MOUSED_SRC"
+        restore_service
+        echo ""
+        print_info "Run the script again with different values:"
+        echo -e "  ${GREEN}$0 --jitter <value> --jump <value>${NC}"
+        ;;
+    *)
+        print_warning "Invalid choice. Restoring original settings..."
+        mv "$MOUSED_BACKUP" "$MOUSED_SRC"
+        restore_service
+        ;;
+esac
+
+echo ""
+print_success "Done!"

--- a/test-physical-click-drag.sh
+++ b/test-physical-click-drag.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Test specifically for physical click and drag issue
+
+LOG_FILE="/tmp/moused-physical-click-drag.log"
+MOUSED_BIN="./moused/bin/moused"
+
+if [ ! -f "$MOUSED_BIN" ]; then
+    echo "Error: moused binary not found at $MOUSED_BIN"
+    echo "Please run 'make' in the moused directory first"
+    exit 1
+fi
+
+echo "Testing Physical Click and Drag"
+echo "================================"
+echo ""
+echo "Stopping moused service..."
+sudo systemctl stop moused
+
+echo ""
+echo "Starting moused in debug mode..."
+echo "Log file: $LOG_FILE"
+echo ""
+echo "IMPORTANT: Please do the following EXACT steps:"
+echo ""
+echo "1. DO NOT touch the trackpad yet"
+echo "2. Press Enter to start capturing"
+echo "3. Press and HOLD the physical click button"
+echo "4. While holding the button, move your finger on the trackpad"
+echo "5. Release the button"
+echo "6. Press Enter to stop"
+echo ""
+read -p "Press Enter when ready to start..."
+
+# Start moused in background
+sudo $MOUSED_BIN -d > "$LOG_FILE" 2>&1 &
+MOUSED_PID=$!
+
+echo ""
+echo "NOW: Press and hold the physical button, then try to move!"
+echo ""
+read -p "Press Enter when done..."
+
+# Stop moused
+sudo kill $MOUSED_PID 2>/dev/null
+wait $MOUSED_PID 2>/dev/null
+
+echo ""
+echo "Log saved to: $LOG_FILE"
+echo ""
+echo "Restarting moused service..."
+sudo systemctl start moused
+
+echo ""
+echo "Done! Log is ready for review."

--- a/test-trackpad.sh
+++ b/test-trackpad.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Script to test trackpad events and capture logs
+
+LOG_DIR="/tmp/moused-debug"
+mkdir -p "$LOG_DIR"
+
+MOUSED_BIN="./moused/bin/moused"
+
+if [ ! -f "$MOUSED_BIN" ]; then
+    echo "Error: moused binary not found at $MOUSED_BIN"
+    echo "Please run 'make' in the moused directory first"
+    exit 1
+fi
+
+# Check if moused service is running
+if systemctl is-active --quiet moused; then
+    echo "Stopping moused service..."
+    sudo systemctl stop moused
+    RESTART_SERVICE=1
+else
+    RESTART_SERVICE=0
+fi
+
+echo "Starting trackpad event tests..."
+echo "Logs will be saved to: $LOG_DIR"
+echo ""
+
+# Function to run a test
+run_test() {
+    local test_name="$1"
+    local test_description="$2"
+    local log_file="$LOG_DIR/${test_name}.log"
+
+    echo "================================================"
+    echo "Test: $test_description"
+    echo "================================================"
+    echo "Starting moused in debug mode..."
+    echo "Log file: $log_file"
+    echo ""
+    echo "Please perform the following action:"
+    echo "  -> $test_description"
+    echo ""
+    echo "Press Enter when ready to start capturing..."
+    read
+
+    # Start moused in background and capture output
+    sudo $MOUSED_BIN -d > "$log_file" 2>&1 &
+    MOUSED_PID=$!
+
+    echo "Capturing events... Perform the action now."
+    echo "Press Enter when done..."
+    read
+
+    # Stop moused
+    sudo kill $MOUSED_PID 2>/dev/null
+    wait $MOUSED_PID 2>/dev/null
+
+    echo "Log saved to: $log_file"
+    echo ""
+    sleep 1
+}
+
+# Test 1: Just moving the cursor
+run_test "01-move-only" "Move your finger on the trackpad (no clicks) - just move the cursor around"
+
+# Test 2: Tap to click
+run_test "02-tap-click" "Do a tap-to-click (quickly tap the trackpad surface)"
+
+# Test 3: Physical click
+run_test "03-physical-click" "Do a physical click (press down on the trackpad button)"
+
+# Test 4: Click and drag attempt
+run_test "04-click-drag" "Try to click and drag (hold physical button down while moving)"
+
+echo "================================================"
+echo "All tests complete!"
+echo "================================================"
+echo ""
+echo "Log files saved in: $LOG_DIR"
+ls -lh "$LOG_DIR"
+echo ""
+echo "You can review the logs with:"
+echo "  cat $LOG_DIR/01-move-only.log"
+echo "  cat $LOG_DIR/02-tap-click.log"
+echo "  cat $LOG_DIR/03-physical-click.log"
+echo "  cat $LOG_DIR/04-click-drag.log"
+echo ""
+
+# Restart service if it was running
+if [ $RESTART_SERVICE -eq 1 ]; then
+    echo "Restarting moused service..."
+    sudo systemctl start moused
+fi
+
+echo "Done!"


### PR DESCRIPTION
The  virtual device was being identified as a mouse rather than a touchpad, which created some odd behavior - most notably, physical click and hold while dragging with another finger would prevent the cursor from moving. Adding touchpad properties to the virtual device so it can be correctly identified by the system fixes this. 

In addition, I've added some noise supression that should reduce the touchpad jitter that happens on this device as well as reduce the movement noise that happens when you lift your finger, making it difficult to point at things sometimes. The values could potentially use more fine-tuning but the current implementation seems to improve things quite a bit. 

Closes #25 and #21 .

I am using and testing on a Minibook X N150. 